### PR TITLE
Applied likely versions as per last Jenkin CI run and tag values

### DIFF
--- a/config/020-delius-core.tfvars
+++ b/config/020-delius-core.tfvars
@@ -3,24 +3,18 @@
 # This congig relates to the code needed in the DELIUS section of the pipeline.
 # example DAMS/{env name}/DELIUS
 
-# Infrastructure Terraform
+Infrastructure Terraform
 hmpps-delius-core-terraform = {
-  alfresco-dev         = "1.5.0"
-  alfresco-sbx         = "1.5.0"
-  delius-core-dev      = "1.5.0"
-  delius-core-sandpit  = "1.5.0"
-  delius-int           = "1.5.0"
-  delius-mis-dev       = "1.5.0"
-  delius-mis-test      = "1.4.0"
-  delius-new-tech-dev  = "1.5.0"
-  delius-new-tech-sbx  = "1.5.0"
-  delius-perf          = "1.5.0"
-  delius-po-test1      = "1.5.0"
-  delius-pre-prod      = "1.5.0"
-  delius-prod          = "1.4.0"
-  delius-stage         = "1.5.0"
-  delius-test          = "1.5.0"
-  delius-training      = "1.5.0"
-  delius-training-test = "1.5.0"
-  mis-nart-dev         = "1.5.0"
+  delius-core-dev      = ""
+  delius-core-sandpit  = ""
+  delius-int           = "1.6.0" #2020-05-15:12:24
+  delius-mis-dev       = "1.9.0" #2020-01-23:16:04
+  delius-perf          = "1.8.0" #2020-05-28:14:15
+  delius-po-test1      = "0.1.0" #2019-12-04
+  delius-pre-prod      = "1.6.0" #2020-05-19:14:20
+  delius-prod          = "1.6.0" #2020-05-15:19:34
+  delius-stage         = "1.6.0" #2020-05-26:10:28
+  delius-test          = "1.7.0" #2020-05-27:09:29
+  delius-training      = "1.6.0" #2020-05-18:12:37
+  delius-training-test = "0.1.0" #2020-04-08:10:03
 }


### PR DESCRIPTION
dev and sandpit left empty as they run either master or a feature/dev branch

1.9.0 May 29, 2020
1.8.0 May 28, 2020
1.7.0 May 27, 2020 10:18
1.6.0 May 15, 2020 10:23
1.5.0
1.4.0
1.3.0
1.2.0
1.1.0
1.0.0 Apr 24, 2020 16:59