### PR TITLE
Removed star due to constraint on paramstore.

### DIFF
--- a/config/020-delius-core.tfvars
+++ b/config/020-delius-core.tfvars
@@ -35,16 +35,16 @@ delius-core-hmpps-env-configs = {
 }
 
 delius-core-db-ami = {
-  delius-core-dev      = "HMPPS Delius-Core OracleDB master *"
-  delius-core-sandpit  = "HMPPS Delius-Core OracleDB master *"
-  delius-int           = "HMPPS Delius-Core OracleDB master *"
-  delius-mis-dev       = "HMPPS Delius-Core OracleDB master *"
-  delius-training-test = "HMPPS Delius-Core OracleDB master *"
-  delius-training      = "HMPPS Delius-Core OracleDB master *"
-  delius-test          = "HMPPS Delius-Core OracleDB master *"
-  delius-po-test1      = "HMPPS Delius-Core OracleDB master *"
-  delius-perf          = "HMPPS Delius-Core OracleDB master *"
-  delius-stage         = "HMPPS Delius-Core OracleDB master *"
-  delius-pre-prod      = "HMPPS Delius-Core OracleDB master *"
-  delius-prod          = "HMPPS Delius-Core OracleDB master *"
+  delius-core-dev      = "HMPPS Delius-Core OracleDB master"
+  delius-core-sandpit  = "HMPPS Delius-Core OracleDB master"
+  delius-int           = "HMPPS Delius-Core OracleDB master"
+  delius-mis-dev       = "HMPPS Delius-Core OracleDB master"
+  delius-training-test = "HMPPS Delius-Core OracleDB master"
+  delius-training      = "HMPPS Delius-Core OracleDB master"
+  delius-test          = "HMPPS Delius-Core OracleDB master"
+  delius-po-test1      = "HMPPS Delius-Core OracleDB master"
+  delius-perf          = "HMPPS Delius-Core OracleDB master"
+  delius-stage         = "HMPPS Delius-Core OracleDB master"
+  delius-pre-prod      = "HMPPS Delius-Core OracleDB master"
+  delius-prod          = "HMPPS Delius-Core OracleDB master"
 }


### PR DESCRIPTION
Value 'HMPPS Delius-Core OracleDB master *' at 'tags.4.member.value' failed to satisfy constraint: Member must satisfy regular expression pattern: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$.