### PR TITLE
Set delius-training to "Tag vALS-68_1.15.0" of delius-core-terraform …

### DIFF
--- a/config/020-delius-core.tfvars
+++ b/config/020-delius-core.tfvars
@@ -14,7 +14,7 @@ hmpps-delius-core-terraform = {
   delius-perf          = "2.0.0"
   delius-stage         = "2.0.0"
   delius-training-test = "2.0.0"
-  delius-training      = "1.14.0"
+  delius-training      = "vALS-68_1.15.0"
   delius-pre-prod      = "1.12.0"
   delius-prod          = "1.14.0"
 }


### PR DESCRIPTION
…for the HA reduction.

This doesn't change anything around the AWS database resources but splits the DB into three sub directories.
The difference between tag 1.15.0 and 1.12.0 are changes to the Jenkinsfile which is always pulled from master branch.