### PR TITLE
set delius-core terraform to 2.4.0 and vALS-1362_1.15.0 (cherry picke…

### DIFF
--- a/config/020-delius-core.tfvars
+++ b/config/020-delius-core.tfvars
@@ -7,16 +7,16 @@
 hmpps-delius-core-terraform = {
   # delius-core-dev      = "" # force to default to branch
   # delius-core-sandpit  = "" # force to default to branch
-  delius-int           = "2.0.0"
-  delius-mis-dev       = "2.0.0"
-  delius-test          = "2.0.0"
-  delius-po-test1      = "2.0.0"
-  delius-perf          = "2.0.0"
-  delius-stage         = "2.0.0"
-  delius-training-test = "2.0.0"
-  delius-training      = "vALS-68_1.15.0"
-  delius-pre-prod      = "vALS-68_1.15.0"
-  delius-prod          = "vALS-68_1.15.0"
+  delius-int           = "2.4.0"
+  delius-mis-dev       = "2.4.0"
+  delius-test          = "2.4.0"
+  delius-po-test1      = "2.4.0"
+  delius-perf          = "2.4.0"
+  delius-stage         = "2.4.0"
+  delius-training-test = "2.4.0"
+  delius-training      = "vALS-1362_1.15.0"
+  delius-pre-prod      = "vALS-1362_1.15.0"
+  delius-prod          = "vALS-1362_1.15.0"
 }
 
 delius-core-hmpps-env-configs = {


### PR DESCRIPTION
…d from 2.4.0) to pin delius db module version

For differences see
https://github.com/ministryofjustice/hmpps-delius-core-terraform/compare/2.0.0...2.4.0

and
https://github.com/ministryofjustice/hmpps-delius-core-terraform/compare/vALS-68_1.15.0...vALS-1362_1.15.0