### PR TITLE
Updated mis terraform repo version for auto-test env

### DIFF
--- a/config/050-mis.tfvars
+++ b/config/050-mis.tfvars
@@ -8,7 +8,7 @@
 # #Infrastructure Terraform
 hmpps-mis-terraform-repo = {
   delius-mis-dev       = "latest"  #No longer in use, uses latest code
-  delius-auto-test     = "0.83.0"  #Running config version 1.748.0
+  delius-auto-test     = "0.84.0"  #Running config version 1.748.0
   delius-stage         = "0.82.0"
   delius-pre-prod      = "0.82.0"
   delius-prod          = "0.82.0"

--- a/config/050-mis.tfvars
+++ b/config/050-mis.tfvars
@@ -9,7 +9,7 @@
 hmpps-mis-terraform-repo = {
   delius-mis-dev       = "latest"  #No longer in use, uses latest code
   delius-auto-test     = "0.84.0"  #Running config version 1.748.0
-  delius-stage         = "0.82.0"
+  delius-stage         = "0.84.0"
   delius-pre-prod      = "0.82.0"
   delius-prod          = "0.82.0"
 }


### PR DESCRIPTION
Updated new mis terraform version for auto-test env. Ticket no. https://dsdmoj.atlassian.net/browse/NIT-31
