### PR TITLE
deploy s3 dfi reports bucket permissions changes

### DIFF
--- a/config/050-mis.tfvars
+++ b/config/050-mis.tfvars
@@ -7,39 +7,39 @@
 
 # #Infrastructure Terraform
 hmpps-mis-terraform-repo = {
-  delius-mis-dev       = "latest"  #No longer in use, uses latest code
-  delius-stage         = "0.114.1"
-  delius-pre-prod      = "0.114.1"
-  delius-prod          = "0.114.1"
+  delius-mis-dev  = "latest" #No longer in use, uses latest code
+  delius-stage    = "0.121.0"
+  delius-pre-prod = "0.121.0"
+  delius-prod     = "0.121.0"
 }
 
 mis-hmpps-env-configs = {
-  delius-mis-dev       = "1.1811.0"
-  delius-stage         = "1.968.0"   #No longer in use
-  delius-pre-prod      = "1.968.0"   #No longer in use
-  delius-prod          = "1.968.0"   #No longer in use
+  delius-mis-dev  = "1.1811.0"
+  delius-stage    = "1.968.0" #No longer in use
+  delius-pre-prod = "1.968.0" #No longer in use
+  delius-prod     = "1.968.0" #No longer in use
 }
 
 # The HMPPS OracleDB 19c master 1618992806 ami is used for bootstrapping
 # Oracle 19c Database and Oracle 19c Grid combination
 
 mis-db-ami = {
-  delius-mis-dev      = "HMPPS OracleDB 19c master 1618992806"
-  delius-stage        = "HMPPS OracleDB 19c master 1618992806"
-  delius-pre-prod     = "HMPPS OracleDB 19c master 1618992806"
-  delius-prod         = "HMPPS OracleDB 19c master 1618992806"
+  delius-mis-dev  = "HMPPS OracleDB 19c master 1618992806"
+  delius-stage    = "HMPPS OracleDB 19c master 1618992806"
+  delius-pre-prod = "HMPPS OracleDB 19c master 1618992806"
+  delius-prod     = "HMPPS OracleDB 19c master 1618992806"
 }
 
 misboe-db-ami = {
-  delius-mis-dev      = "HMPPS OracleDB 19c master 1618992806"
-  delius-stage        = "HMPPS OracleDB 19c master 1618992806"
-  delius-pre-prod     = "HMPPS OracleDB 19c master 1618992806"
-  delius-prod         = "HMPPS OracleDB 19c master 1618992806"
+  delius-mis-dev  = "HMPPS OracleDB 19c master 1618992806"
+  delius-stage    = "HMPPS OracleDB 19c master 1618992806"
+  delius-pre-prod = "HMPPS OracleDB 19c master 1618992806"
+  delius-prod     = "HMPPS OracleDB 19c master 1618992806"
 }
 
 misdsd-db-ami = {
-  delius-mis-dev      = "HMPPS OracleDB 19c master 1618992806"
-  delius-stage        = "HMPPS OracleDB 19c master 1618992806"
-  delius-pre-prod     = "HMPPS OracleDB 19c master 1618992806"
-  delius-prod         = "HMPPS OracleDB 19c master 1618992806"
+  delius-mis-dev  = "HMPPS OracleDB 19c master 1618992806"
+  delius-stage    = "HMPPS OracleDB 19c master 1618992806"
+  delius-pre-prod = "HMPPS OracleDB 19c master 1618992806"
+  delius-prod     = "HMPPS OracleDB 19c master 1618992806"
 }


### PR DESCRIPTION
- change in hmpps-mis-terraform-repo requires expanding s3 bucket policy for dfi reports to be shared to modernisation-platform delius-mis environments for ETL migration to continue
- manually copying the reports over is not an option