### PR TITLE
deploy delius-mis-dev fix for mariadb deprecated on t2 to fix pipeline

### DIFF
--- a/config/050-mis.tfvars
+++ b/config/050-mis.tfvars
@@ -14,7 +14,7 @@ hmpps-mis-terraform-repo = {
 }
 
 mis-hmpps-env-configs = {
-  delius-mis-dev  = "1.1811.0"
+  delius-mis-dev  = "1.2000.0"
   delius-stage    = "1.968.0" #No longer in use
   delius-pre-prod = "1.968.0" #No longer in use
   delius-prod     = "1.968.0" #No longer in use


### PR DESCRIPTION
- update version for delius-mis-dev to fix mariadb t2 compatibility issue
  - https://github.com/ministryofjustice/hmpps-env-configs/pull/2546

Main challenge I can foresee in here is that version 1811 was deployed back in Oct 2024, nearly a year ago...

